### PR TITLE
Centralize NuGet package versions using Directory.Packages.props

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,10 @@
 <Project>
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
+  
+  <!-- Code Analysis Packages -->
   <ItemGroup>
     <PackageReference Include="Roslynator.Analyzers" Version="4.14.0">
       <PrivateAssets>all</PrivateAssets>
@@ -12,7 +15,100 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+  
+  <!-- Package Versions -->
   <ItemGroup>
-    <PackageReference Include="System.Text.Encodings.Web" Version="9.0.8" />
+    <!-- Ardalis -->
+    <PackageVersion Include="Ardalis.GuardClauses" Version="5.0.0" />
+    
+    <!-- Aspire Packages -->
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.4.1" />
+    <PackageVersion Include="Aspire.Hosting.Keycloak" Version="9.4.1-preview.1.25408.4" />
+    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="9.4.1" />
+    <PackageVersion Include="Aspire.Hosting.Testing" Version="9.4.1" />
+    <PackageVersion Include="Aspire.Keycloak.Authentication" Version="9.4.1-preview.1.25408.4" />
+    <PackageVersion Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.4.1" />
+    
+    <!-- Blazor and Authentication -->
+    <PackageVersion Include="Blazored.FluentValidation" Version="2.2.0" />
+    <PackageVersion Include="Blazored.LocalStorage" Version="4.5.0" />
+    <PackageVersion Include="CorrelationId" Version="3.0.1" />
+    <PackageVersion Include="Duende.AccessTokenManagement.OpenIdConnect" Version="3.2.0" />
+    
+    <!-- FastEndpoints -->
+    <PackageVersion Include="FastEndpoints" Version="7.0.1" />
+    <PackageVersion Include="FastEndpoints.ClientGen.Kiota" Version="7.0.1" />
+    <PackageVersion Include="FastEndpoints.Swagger" Version="7.0.1" />
+    <PackageVersion Include="FastEndpoints.Testing" Version="7.0.1" />
+    
+    <!-- FluentValidation -->
+    <PackageVersion Include="FluentValidation" Version="12.0.0" />
+    <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
+    
+    <!-- Identity -->
+    <PackageVersion Include="IdentityModel.AspNetCore" Version="4.3.0" />
+    
+    <!-- Microsoft Packages -->
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.8.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.4.1" />
+    <PackageVersion Include="Microsoft.Kiota.Abstractions" Version="1.19.1" />
+    <PackageVersion Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.19.1" />
+    <PackageVersion Include="Microsoft.Kiota.Serialization.Json" Version="1.19.1" />
+    <PackageVersion Include="Microsoft.NET.ILLink.Tasks" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.NET.Sdk.WebAssembly.Pack" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Playwright" Version="1.54.0" />
+    
+    <!-- MudBlazor -->
+    <PackageVersion Include="MudBlazor" Version="8.11.0" />
+    
+    <!-- Security -->
+    <PackageVersion Include="NetEscapades.AspNetCore.SecurityHeaders" Version="1.1.0" />
+    
+    <!-- OpenTelemetry -->
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
+    
+    <!-- Scalar -->
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.7.2" />
+    
+    <!-- Serilog -->
+    <PackageVersion Include="Serilog" Version="4.3.0" />
+    <PackageVersion Include="Serilog.AspNetCore" Version="9.0.0" />
+    <PackageVersion Include="Serilog.Exceptions" Version="8.4.0+build.694" />
+    <PackageVersion Include="Serilog.Extensions.Logging" Version="9.0.2" />
+    <PackageVersion Include="Serilog.Settings.Configuration" Version="9.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Async" Version="2.1.0" />
+    <PackageVersion Include="Serilog.Sinks.BrowserConsole" Version="8.0.0" />
+    <PackageVersion Include="Serilog.Sinks.BrowserHttp" Version="1.0.0-dev-00032" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Debug" Version="3.0.0" />
+    
+    <!-- Testing -->
+    <PackageVersion Include="Shouldly" Version="4.3.0" />
+    
+    <!-- System Packages -->
+    <PackageVersion Include="System.Net.Http.Json" Version="9.0.8" />
+    <PackageVersion Include="System.Text.Encodings.Web" Version="9.0.8" />
+    
+    <!-- Testing Framework -->
+    <PackageVersion Include="TUnit" Version="0.57.1" />
+    <PackageVersion Include="TUnit.Playwright" Version="0.57.1" />
+    
+    <!-- YARP -->
+    <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
   </ItemGroup>
 </Project>

--- a/src/Aspire/AppHost/HeadStart.Aspire.AppHost.csproj
+++ b/src/Aspire/AppHost/HeadStart.Aspire.AppHost.csproj
@@ -11,9 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.4.1" />
-    <PackageReference Include="Aspire.Hosting.Keycloak" Version="9.4.1-preview.1.25408.4" />
-    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="9.4.1" />
+    <PackageReference Include="Aspire.Hosting.AppHost" />
+    <PackageReference Include="Aspire.Hosting.Keycloak" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire/ServiceDefaults/HeadStart.Aspire.ServiceDefaults.csproj
+++ b/src/Aspire/ServiceDefaults/HeadStart.Aspire.ServiceDefaults.csproj
@@ -10,13 +10,13 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App"/>
 
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.8.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.4.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0"/>
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0"/>
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0"/>
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0"/>
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0"/>
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
   </ItemGroup>
 
 </Project>

--- a/src/BFF/HeadStart.BFF.csproj
+++ b/src/BFF/HeadStart.BFF.csproj
@@ -3,14 +3,14 @@
     <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Ardalis.GuardClauses" Version="5.0.0" />
-    <PackageReference Include="Aspire.Keycloak.Authentication" Version="9.4.1-preview.1.25408.4" />
-    <PackageReference Include="Duende.AccessTokenManagement.OpenIdConnect" Version="3.2.0" />
-    <PackageReference Include="IdentityModel.AspNetCore" Version="4.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.8" />
-    <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" Version="1.1.0" />
-    <PackageReference Include="Yarp.ReverseProxy" Version="2.3.0" />
+    <PackageReference Include="Ardalis.GuardClauses" />
+    <PackageReference Include="Aspire.Keycloak.Authentication" />
+    <PackageReference Include="Duende.AccessTokenManagement.OpenIdConnect" />
+    <PackageReference Include="IdentityModel.AspNetCore" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" />
+    <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" />
+    <PackageReference Include="Yarp.ReverseProxy" />
     </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Aspire\ServiceDefaults\HeadStart.Aspire.ServiceDefaults.csproj" />

--- a/src/Client/HeadStart.Client.csproj
+++ b/src/Client/HeadStart.Client.csproj
@@ -6,28 +6,28 @@
     <PackageId>HeadStart.Client</PackageId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Ardalis.GuardClauses" Version="5.0.0" />
-    <PackageReference Include="Blazored.FluentValidation" Version="2.2.0" />
-    <PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
-    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="9.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.8" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.19.1" />
-    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.19.1" />
-    <PackageReference Include="Microsoft.Kiota.Serialization.Json" Version="1.19.1" />
-    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="9.0.8" />
-    <PackageReference Include="Microsoft.NET.Sdk.WebAssembly.Pack" Version="9.0.8" />
-    <PackageReference Include="MudBlazor" Version="8.11.0" />
-    <PackageReference Include="Serilog" Version="4.3.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
-    <PackageReference Include="Serilog.Exceptions" Version="8.4.0+build.694" />
-    <PackageReference Include="Serilog.Sinks.BrowserConsole" Version="8.0.0" />
-    <PackageReference Include="Serilog.Sinks.BrowserHttp" Version="1.0.0-dev-00032" />
-    <PackageReference Include="System.Net.Http.Json" Version="9.0.8" />
+    <PackageReference Include="Ardalis.GuardClauses" />
+    <PackageReference Include="Blazored.FluentValidation" />
+    <PackageReference Include="Blazored.LocalStorage" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" />
+    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" />
+    <PackageReference Include="Microsoft.Kiota.Serialization.Json" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" />
+    <PackageReference Include="Microsoft.NET.Sdk.WebAssembly.Pack" />
+    <PackageReference Include="MudBlazor" />
+    <PackageReference Include="Serilog" />
+    <PackageReference Include="Serilog.Extensions.Logging" />
+    <PackageReference Include="Serilog.Exceptions" />
+    <PackageReference Include="Serilog.Sinks.BrowserConsole" />
+    <PackageReference Include="Serilog.Sinks.BrowserHttp" />
+    <PackageReference Include="System.Net.Http.Json" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharedKernel.Models\HeadStart.SharedKernel.Models.csproj" />

--- a/src/SharedKernel/HeadStart.SharedKernel.csproj
+++ b/src/SharedKernel/HeadStart.SharedKernel.csproj
@@ -6,20 +6,20 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Ardalis.GuardClauses" Version="5.0.0" />
-        <PackageReference Include="CorrelationId" Version="3.0.1" />
-        <PackageReference Include="FluentValidation" Version="12.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.8" />
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.8" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.8" />
-        <PackageReference Include="Serilog" Version="4.3.0" />
-        <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
-        <PackageReference Include="Serilog.Exceptions" Version="8.4.0+build.694" />
-        <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
-        <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
-        <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
-        <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
-        <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
+        <PackageReference Include="Ardalis.GuardClauses" />
+        <PackageReference Include="CorrelationId" />
+        <PackageReference Include="FluentValidation" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.Logging" />
+        <PackageReference Include="Serilog" />
+        <PackageReference Include="Serilog.AspNetCore" />
+        <PackageReference Include="Serilog.Exceptions" />
+        <PackageReference Include="Serilog.Extensions.Logging" />
+        <PackageReference Include="Serilog.Settings.Configuration" />
+        <PackageReference Include="Serilog.Sinks.Async" />
+        <PackageReference Include="Serilog.Sinks.Console" />
+        <PackageReference Include="Serilog.Sinks.Debug" />
     </ItemGroup>
 
 </Project>

--- a/src/WebAPI/HeadStart.WebAPI.csproj
+++ b/src/WebAPI/HeadStart.WebAPI.csproj
@@ -4,12 +4,12 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Aspire.Keycloak.Authentication" Version="9.4.1-preview.1.25408.4" />
-    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.4.1" />
-    <PackageReference Include="FastEndpoints" Version="7.0.1" />
-    <PackageReference Include="FastEndpoints.ClientGen.Kiota" Version="7.0.1" />
-    <PackageReference Include="FastEndpoints.Swagger" Version="7.0.1" />
-    <PackageReference Include="Scalar.AspNetCore" Version="2.7.2" />
+    <PackageReference Include="Aspire.Keycloak.Authentication" />
+    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="FastEndpoints" />
+    <PackageReference Include="FastEndpoints.ClientGen.Kiota" />
+    <PackageReference Include="FastEndpoints.Swagger" />
+    <PackageReference Include="Scalar.AspNetCore" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Aspire\ServiceDefaults\HeadStart.Aspire.ServiceDefaults.csproj" />

--- a/tests/HeadStart.IntegrationTests/HeadStart.IntegrationTests.csproj
+++ b/tests/HeadStart.IntegrationTests/HeadStart.IntegrationTests.csproj
@@ -10,13 +10,13 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.Testing" Version="9.4.1" />
-    <PackageReference Include="FastEndpoints.Testing" Version="7.0.1"/>
-    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.19.1" />
-    <PackageReference Include="Microsoft.Playwright" Version="1.54.0" />
-    <PackageReference Include="Shouldly" Version="4.3.0"/>
-    <PackageReference Include="TUnit" Version="0.57.1" />
-    <PackageReference Include="TUnit.Playwright" Version="0.57.1" />
+    <PackageReference Include="Aspire.Hosting.Testing" />
+    <PackageReference Include="FastEndpoints.Testing" />
+    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" />
+    <PackageReference Include="Microsoft.Playwright" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="TUnit" />
+    <PackageReference Include="TUnit.Playwright" />
   </ItemGroup>
 
 


### PR DESCRIPTION
Resolves #22

This PR centralizes all NuGet package versions into Directory.Packages.props for improved package management across the solution.

## Changes
- Move all package versions from project files to Directory.Packages.props
- Enable centralized package version management with ManagePackageVersionsCentrally
- Remove Version attributes from all PackageReference elements
- Organize packages by category with clear comments
- Improves consistency and maintainability across solution

Generated with [Claude Code](https://claude.ai/code)